### PR TITLE
Renamed python-call to format-python-call to remove conflict with py4…

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -6,7 +6,5 @@
 (defpackage :ulf2english
   (:use :cl :ttt :cl-strings :cl-json :gute :ulf-lib :inferior-shell :lisp-unit :drakma :py4cl)
   (:shadow :insert)
-  (:shadowing-import-from :cl-ppcre)
-  (:shadowing-import-from :py4cl python-call python-method)
   (:export ulf2english))
 

--- a/pattern-en.lisp
+++ b/pattern-en.lisp
@@ -22,7 +22,7 @@
 ;;
 ;; At the moment this function assumes that the required arguments may be
 ;; strings, whereas keyed arguments are not.
-(defun python-call (fnname required-args keyed-args)
+(defun format-python-call (fnname required-args keyed-args)
   (let ((rarg-str (format nil "~{~s~^,~}" required-args))
         (karg-str (format nil "~{~a~^,~}"
                           (loop for (key . value) in keyed-args
@@ -156,7 +156,7 @@
                     (negated . ,negated)
                     (parse . ,parse)))
          ;; Construct the Python function call.
-         (python-call (python-call 'conjugate (list verb) arglist)))
+         (python-call (format-python-call 'conjugate (list verb) arglist)))
     ;; Since it's all the same case anyway, make it upper case so it doesn't force
     ;; a case sensitive symbol.
     (string-upcase
@@ -169,7 +169,7 @@
 (defun pattern-en-pluralize (noun &key (python-method 'py4cl)
                                        (preserve-case nil))
   (assert (member python-method *python-call-methods*))
-  (let* ((python-call (python-call 'pluralize (list noun) nil))
+  (let* ((python-call (format-python-call 'pluralize (list noun) nil))
          (rawout (make-pattern-en-call python-call python-method)))
     (if preserve-case rawout (string-upcase rawout))))
 
@@ -178,7 +178,7 @@
 (defun pattern-en-superlative (adj &key (python-method 'py4cl)
                                         (preserve-case nil))
   (assert (member python-method *python-call-methods*))
-  (let* ((python-call (python-call 'superlative (list adj) nil))
+  (let* ((python-call (format-python-call 'superlative (list adj) nil))
          (rawout (make-pattern-en-call python-call python-method)))
     (if preserve-case rawout (string-upcase rawout))))
 
@@ -187,7 +187,7 @@
 (defun pattern-en-comparative (adj &key (python-method 'py4cl)
                                         (preserve-case nil))
   (assert (member python-method *python-call-methods*))
-  (let* ((python-call (python-call 'comparative (list adj) nil))
+  (let* ((python-call (format-python-call 'comparative (list adj) nil))
          (rawout (make-pattern-en-call python-call python-method)))
     (if preserve-case rawout (string-upcase rawout))))
 


### PR DESCRIPTION
…cl function. Then eliminated the shadowing import from the package definition.

This is to fix a subtle bug that occurred in the Eta project. The `python-call` function naming conflict between ulf2english and py4cl was leading to the incorrect function being called in the Eta project, thus leading to an error. While I'm not exactly certain of the details of this bug, it seems to be related to the shadowing import from py4cl. Shadowing import seems to lead to symbols external to the importing package being re-written.

For example, in the version of the code prior to this request, `python-call` would raise an error when only `:py4cl` is loaded, but then work after `:ulf2english` is loaded even when prefixing with the `py4cl` package because this symbol is being completely overwritten.
```
* (ql:quickload :py4cl)
To load "py4cl":
  Load 1 ASDF system:
    py4cl
; Loading "py4cl"

(:PY4CL)
* (use-package :py4cl)

T
* (python-call 'hi '("be") '((tense . present)))

debugger invoked on a TYPE-ERROR @537254ED in thread
#<THREAD "main thread" RUNNING {1001834103}>:
  The value
    PRESENT
  is not of type
    LIST

Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [ABORT] Exit debugger, returning to top level.

((:METHOD PY4CL::PYTHONIZE (CONS)) (TENSE . PRESENT)) [fast-method]
   source: (DOLIST (VAL OBJ)
             (WRITE-STRING (PYTHONIZE VAL) STREAM)
             (WRITE-CHAR #\, STREAM))
0]

* (ql:quickload :ulf2english)
To load "ulf2english":
  Load 1 ASDF system:
    ulf2english
; Loading "ulf2english"
.........
(:ULF2ENGLISH)
* (python-call 'hi '("be") '((tense . present)))

"hi(\"be\",tense=PRESENT)"
* (py4cl:python-call 'hi '("be") '((tense . present)))

"hi(\"be\",tense=PRESENT)"
```

In this corrected version, this no longer happens.
```
* (ql:quickload :py4cl)
To load "py4cl":
  Load 1 ASDF system:
    py4cl
; Loading "py4cl"
..
(:PY4CL)
* (use-package :py4cl)

T
* (python-call 'hi '("be") '((tense . present)))

debugger invoked on a TYPE-ERROR @537254ED in thread
#<THREAD "main thread" RUNNING {1001834103}>:
  The value
    PRESENT
  is not of type
    LIST

Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [ABORT] Exit debugger, returning to top level.

((:METHOD PY4CL::PYTHONIZE (CONS)) (TENSE . PRESENT)) [fast-method]
   source: (DOLIST (VAL OBJ)
             (WRITE-STRING (PYTHONIZE VAL) STREAM)
             (WRITE-CHAR #\, STREAM))
0]

* (ql:quickload :ulf2english)
To load "ulf2english":
  Load 1 ASDF system:
    ulf2english
; Loading "ulf2english"
..................................................
[package ulf2english].....
(:ULF2ENGLISH)
* (python-call 'hi '("be") '((tense . present)))

debugger invoked on a TYPE-ERROR @537254ED in thread
#<THREAD "main thread" RUNNING {1001834103}>:
  The value
    PRESENT
  is not of type
    LIST

Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [ABORT] Exit debugger, returning to top level.

((:METHOD PY4CL::PYTHONIZE (CONS)) (TENSE . PRESENT)) [fast-method]
   source: (DOLIST (VAL OBJ)
             (WRITE-STRING (PYTHONIZE VAL) STREAM)
             (WRITE-CHAR #\, STREAM))
0]

* (py4cl:python-call 'hi '("be") '((tense . present)))

debugger invoked on a TYPE-ERROR @537254ED in thread
#<THREAD "main thread" RUNNING {1001834103}>:
  The value
    PRESENT
  is not of type
    LIST

Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [ABORT] Exit debugger, returning to top level.

((:METHOD PY4CL::PYTHONIZE (CONS)) (TENSE . PRESENT)) [fast-method]
   source: (DOLIST (VAL OBJ)
             (WRITE-STRING (PYTHONIZE VAL) STREAM)
             (WRITE-CHAR #\, STREAM))
0]
```